### PR TITLE
Fix 83 default table sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-...
+### Added
+- Support for defining initial table ordering via css class on `TableHeader` of `table.datatable`:
+  - `default-sort` to mark the default sort column
+  - `sort-desc` to set the default sort direction to descending
+
+### Fixed
+- Default table sorting by Delivery Date (Ascending / Soonest First) #83

--- a/app/jobtracker/templates/partials/phase/tables/basic_table.html
+++ b/app/jobtracker/templates/partials/phase/tables/basic_table.html
@@ -23,7 +23,7 @@
             <th class="text-uppercase text-secondary text-xxs font-weight-bolder  ps-2">
             QA
             </th>
-            <th class="text-uppercase text-secondary text-xxs font-weight-bolder  ps-2">
+            <th class="text-uppercase text-secondary text-xxs font-weight-bolder  ps-2 default-sort">
             Delivery
             </th>
             <th scope="col" style="width:10%;" class="text-uppercase col-1 text-secondary text-xxs font-weight-bolder  ps-2">

--- a/app/jobtracker/templates/partials/phase/tables/pqa_table.html
+++ b/app/jobtracker/templates/partials/phase/tables/pqa_table.html
@@ -9,7 +9,7 @@
       <th class="text-uppercase text-secondary text-xxs font-weight-bolder ps-2">Author</th>
       <th class="text-uppercase text-secondary text-xxs font-weight-bolder ps-2">PQ'er</th>
       <th class="text-uppercase text-secondary text-xxs font-weight-bolder ps-2">QA</th>
-      <th class="text-uppercase text-secondary text-xxs font-weight-bolder ps-2">Delivery</th>
+      <th class="text-uppercase text-secondary text-xxs font-weight-bolder ps-2 default-sort">Delivery</th>
       <th scope="col" style="width:10%;" class="text-uppercase col-1 text-secondary text-xxs font-weight-bolder ps-2">Status</th>
       <th scope="col" style="width:10%;" class="text-uppercase col-1 text-secondary text-xxs font-weight-bolder ps-2">Flags</th>
     </tr>

--- a/app/jobtracker/templates/partials/phase/tables/tqa_table.html
+++ b/app/jobtracker/templates/partials/phase/tables/tqa_table.html
@@ -9,7 +9,7 @@
       <th class="text-uppercase text-secondary text-xxs font-weight-bolder ps-2">Author</th>
       <th class="text-uppercase text-secondary text-xxs font-weight-bolder ps-2">TQ'er</th>
       <th class="text-uppercase text-secondary text-xxs font-weight-bolder ps-2">QA</th>
-      <th class="text-uppercase text-secondary text-xxs font-weight-bolder ps-2">Delivery</th>
+      <th class="text-uppercase text-secondary text-xxs font-weight-bolder ps-2 default-sort">Delivery</th>
       <th scope="col" style="width:10%;" class="text-uppercase col-1 text-secondary text-xxs font-weight-bolder ps-2">Status</th>
       <th scope="col" style="width:10%;" class="text-uppercase col-1 text-secondary text-xxs font-weight-bolder ps-2">Flags</th>
     </tr>

--- a/app/templates/js/core.js
+++ b/app/templates/js/core.js
@@ -58,8 +58,13 @@ $(document).ready(function() {
 
 $(function() {
 
-    new DataTable('table.datatable', {
+    const dt = new DataTable('table.datatable', {
         {% include 'js/dtDefaultConfig.js' %}
+    });
+    dt.tables().every(function () {
+        const th = this.table().header().querySelector('th.default-sort');
+        if (!th) return;
+        this.order([th.cellIndex, th.classList.contains("sort-desc") ? 'desc' : 'asc']).draw();
     });
 
     var loadForm = function() {


### PR DESCRIPTION
This PR introduces support for default table sorting via header classes and applies it to key report-focused tables (PQA, TQA, and Basic Table). Tables can now define an initial sort column and direction using default-sort and sort-desc classes.

(Fixes #123)